### PR TITLE
Fix model downloading scripts

### DIFF
--- a/script/download_and_copy_models.sh
+++ b/script/download_and_copy_models.sh
@@ -26,8 +26,8 @@ do
             echo "Copy $i IR files to directory model/"
             cp ${INTEL_OPENVINO_DIR}/deployment_tools/open_model_zoo/tools/downloader/intel/$i/FP16/$i.xml ${INTEL_OPENVINO_DIR}/deployment_tools/open_model_zoo/tools/downloader/intel/$i/FP16/$i.bin $root_path/$target_dir/
         else
-            echo "./downloader.py --name $i  --precisions fp16"
-            ./downloader.py --name $i  --precisions FP16
+            echo "./downloader.py --name $i  --precisions FP16"
+            sudo -E ./downloader.py --name $i  --precisions FP16
 
             if [ -f "${INTEL_OPENVINO_DIR}/deployment_tools/open_model_zoo/tools/downloader/intel/$i/FP16/$i.xml" ]
             then
@@ -35,7 +35,7 @@ do
                 cp ${INTEL_OPENVINO_DIR}/deployment_tools/open_model_zoo/tools/downloader/intel/$i/FP16/$i.xml ${INTEL_OPENVINO_DIR}/deployment_tools/open_model_zoo/tools/downloader/intel/$i/FP16/$i.bin $root_path/$target_dir/
             else
                 echo "Failed to download $i model. "
-                echo "Please manually run command:${INTEL_OPENVINO_DIR}/deployment_tools/tools/model_downloader/downloader.py --name $i --precisions fp16" 
+                echo "Please manually run command:${INTEL_OPENVINO_DIR}/deployment_tools/tools/model_downloader/downloader.py --name $i --precisions FP16" 
             fi
 
         fi

--- a/script/download_models.sh
+++ b/script/download_models.sh
@@ -14,7 +14,7 @@ model_list="face-detection-retail-0004 human-pose-estimation-0001 vehicle-licens
 
 for i in $model_list
 do
-    echo "./downloader.py --name $i  --precisions fp16"
+    echo "./downloader.py --name $i  --precisions FP16"
     ./downloader.py --name $i  --precisions FP16
 
     if [ -f "${INTEL_OPENVINO_DIR}/deployment_tools/open_model_zoo/tools/downloader/intel/$i/FP16/$i.xml" ]
@@ -22,6 +22,6 @@ do
         echo "$i was downloaded successfully"
     else
         echo "Failed to download $i model. "
-        echo "Please manually run command:${INTEL_OPENVINO_DIR}/deployment_tools/tools/model_downloader/downloader.py --name $i --precisions fp16" 
+        echo "Please manually run command:${INTEL_OPENVINO_DIR}/deployment_tools/tools/model_downloader/downloader.py --name $i --precisions FP16" 
     fi
 done


### PR DESCRIPTION
Add "sudo" to the command line of downloading models IR files
in case Openvino is installed to /opt/intel

Also correct the error message of downloading model failure

Signed-off-by: Elaine Wang <elaine.wang@intel.com>